### PR TITLE
Fix support for date

### DIFF
--- a/py_mini_racer/py_mini_racer.py
+++ b/py_mini_racer/py_mini_racer.py
@@ -187,7 +187,8 @@ class PythonValue(ctypes.Structure):
             raise JSEvalException(msg)
         elif self.type == PythonTypes.date.value:
             timestamp = self._double_value()
-            result = datetime.datetime.utcfromtimestamp(timestamp)
+            # JS timestamp are milliseconds, in python we are in seconds
+            result = datetime.datetime.utcfromtimestamp(timestamp / 1000.)
         else:
             raise WrongReturnTypeException("unknown type %d" % self.type)
         return result

--- a/py_mini_racer/py_mini_racer.py
+++ b/py_mini_racer/py_mini_racer.py
@@ -2,11 +2,11 @@
 """ PyMiniRacer main wrappers """
 # pylint: disable=bad-whitespace,too-few-public-methods
 
-import time
 import json
 import ctypes
 import threading
 import pkg_resources
+import datetime
 
 import enum
 
@@ -187,7 +187,7 @@ class PythonValue(ctypes.Structure):
             raise JSEvalException(msg)
         elif self.type == PythonTypes.date.value:
             timestamp = self._double_value()
-            result = time.ctime(timestamp) 
+            result = datetime.datetime.utcfromtimestamp(timestamp)
         else:
             raise WrongReturnTypeException("unknown type %d" % self.type)
         return result

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -7,7 +7,10 @@ import unittest
 import json
 import time
 
+from datetime import datetime
+
 from py_mini_racer import py_mini_racer
+
 
 class Test(unittest.TestCase):
     """ Test basic types """
@@ -25,7 +28,6 @@ class Test(unittest.TestCase):
 
         self.mr = py_mini_racer.MiniRacer()
 
-
     def test_str(self):
         self.valid("'a string'")
         self.valid("'a ' + 'string'")
@@ -34,7 +36,6 @@ class Test(unittest.TestCase):
         ustr = u"\N{GREEK CAPITAL LETTER DELTA}"
         res = self.mr.eval("'" + ustr + "'")
         self.assertEqual(ustr, res)
-
 
     def test_numbers(self):
         self.valid(1)
@@ -81,7 +82,7 @@ class Test(unittest.TestCase):
         self.assertTrue(isinstance(res, py_mini_racer.JSFunction))
 
     def test_invalid_key(self):
-        
+
         fun = """
             var o = {};
             o.__defineGetter__("bar", function() { return null(); });
@@ -93,7 +94,7 @@ class Test(unittest.TestCase):
     def test_date(self):
         val = int(time.time())
         res = self.mr.eval("var a = new Date(%d); a" % val)
-        self.assertEqual(res, time.ctime(val))
+        self.assertEqual(res, datetime.utcfromtimestamp(val))
 
 if __name__ == '__main__':
     import sys

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -91,10 +91,14 @@ class Test(unittest.TestCase):
         with self.assertRaises(py_mini_racer.JSConversionException):
             self.mr.eval(fun)
 
-    def test_date(self):
+    def test_timestamp(self):
         val = int(time.time())
-        res = self.mr.eval("var a = new Date(%d); a" % val)
+        res = self.mr.eval("var a = new Date(%d); a" % (val * 1000))
         self.assertEqual(res, datetime.utcfromtimestamp(val))
+
+    def test_date(self):
+        res = self.mr.eval("var a = new Date(Date.UTC(2014, 0, 2, 3, 4, 5)); a")
+        self.assertEqual(res, datetime(2014, 1, 2, 3, 4, 5))
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
With this modification, py_mini_racer returns datetime
instead of string representation.

ping @aviat 