### PR TITLE
Fix the extension loading for python 3

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ History
 UNRELEASED
 ---------------------
 
+* Fix extension loading for python3
+
 0.1.2 (2016-08-03)
 ---------------------
 

--- a/py_mini_racer/py_mini_racer.py
+++ b/py_mini_racer/py_mini_racer.py
@@ -5,12 +5,16 @@
 import json
 import ctypes
 import threading
-import pkg_resources
 import datetime
+import fnmatch
+
+from pkg_resources import resource_listdir, resource_filename
 
 import enum
 
-EXTENSION_PATH = pkg_resources.resource_filename('py_mini_racer', '_v8.so')
+# In python 3 the extension file name depends on the python version
+EXTENSION_NAME = fnmatch.filter(resource_listdir('py_mini_racer', '.'), '_v8*.so')[0]
+EXTENSION_PATH = resource_filename('py_mini_racer', EXTENSION_NAME)
 
 
 class MiniRacerBaseException(Exception):


### PR DESCRIPTION
In python 3 the so file name include the python version.
This change helps py_mini_racer find the so file even when
it's not named "_v8.so".