### PR TITLE
Allow user to choose an arbitrary V8 build

### DIFF
--- a/py_mini_racer/extension/v8_build.py
+++ b/py_mini_racer/extension/v8_build.py
@@ -127,11 +127,11 @@ def make_flags():
     return ' '.join(flags)
 
 
-def make(path, flags):
+def make(path, flags, target='native'):
     """ Create a release of v8
     """
     with chdir(path):
-        call("make native {}".format(flags))
+        call("make {} {}".format(target, flags))
 
 
 def patch_v8():
@@ -158,12 +158,12 @@ def apply_patches(path, patches_path):
                     applied_patches_file.write(patch + "\n")
 
 
-def build_v8():
+def build_v8(target):
     ensure_v8_src()
     patch_v8()
     flags = make_flags()
-    make(local_path('v8/v8'), flags)
+    make(local_path('v8/v8'), flags, target)
 
 
 if __name__ == '__main__':
-    build_v8()
+    build_v8('native')

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
 import pip
 import sys
 import codecs
@@ -46,6 +47,9 @@ setup_requires = [str(sr.req) for sr in parsed_setup_requirements]
 test_requirements = [str(tr.req) for tr in parsed_test_requirements]
 
 
+def get_target():
+    return os.environ.get('V8_TARGET', 'native')
+
 def local_path(path):
     """ Return path relative to this file
     """
@@ -73,9 +77,12 @@ def is_depot_tools_checkout():
 def libv8_object(object_name):
     """ Return a path for object_name which is OS independent
     """
-    filename = join(V8_LIB_DIRECTORY, "out/native/", object_name)
+    filename = join(V8_LIB_DIRECTORY, "out/{}/".format(get_target()),
+                    object_name)
     if not isfile(filename):
-        filename = join(V8_LIB_DIRECTORY, "out/native/obj.target/tools/gyp/", object_name)
+        filename = join(V8_LIB_DIRECTORY,
+                        "out/{}/obj.target/tools/gyp/".format(get_target()),
+                        object_name)
     return filename
 
 
@@ -167,7 +174,10 @@ class MiniRacerBuildV8(Command):
 
         if not is_v8_built():
             print("building v8")
-            build_v8()
+            target = os.environ.get('V8_TARGET', 'native')
+            build_v8(target)
+        else:
+            print("v8 is already built")
 
 setup(
     name='py_mini_racer',


### PR DESCRIPTION
The environment variable `V8_TARGET` can be set to require a specific V8 build.

E.g.:

    V8_TARGET=x64.debug python setup.py build_v8