### PR TITLE
Fix binaries with libc < 2.17

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ EXTRA_LINK_ARGS = [
 if sys.platform[:6] == "darwin":
     EXTRA_LINK_ARGS += ['-stdlib=libstdc++', '-lpthread']
 elif sys.platform.startswith('linux'):
-    EXTRA_LINK_ARGS += []
+    EXTRA_LINK_ARGS += ['-lrt']
 
 
 PY_MINI_RACER_EXTENSION = Extension(


### PR DESCRIPTION
According to the manpage of clock_gettime:

`Link with -lrt (only for glibc versions before 2.17).`

So we link PyMiniRacer with `-lrt` on Linux.