### PR TITLE
Fix the build failure on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ branches:
   only:
     - master
 
-language: c
 matrix:
   include:
     - dist: trusty
@@ -16,6 +15,7 @@ matrix:
         - ./upload_artifacts_linux.sh
     - os: osx
       osx_image: xcode9.4
+      compiler: clang
       script:
         - ./build_mac_os_x_wheels.sh
       after_success:

--- a/build_mac_os_x_wheels.sh
+++ b/build_mac_os_x_wheels.sh
@@ -11,6 +11,8 @@ for PYVERSION in 2.7 3.4 3.5 3.6 3.7; do
     . ./venv_${PYVERSION}/bin/activate
     pip install certifi
     pip install -r requirements/setup.txt
-    python setup.py bdist_wheel --verbose
+    python setup.py build_v8
+    export LDSHARED="clang++ -bundle -undefined dynamic_lookup -arch i386 -arch x86_64"
+    python setup.py bdist_wheel
     deactivate
 done

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ def is_v8_built():
     """
     if V8_PATH:
         return True
-    return all(get_raw_static_lib_path())
+    return all(isfile(static_filepath) for static_filepath in get_raw_static_lib_path())
 
 
 def is_depot_tools_checkout():
@@ -88,12 +88,16 @@ def is_depot_tools_checkout():
 def libv8_object(object_name):
     """ Return a path for object_name which is OS independent
     """
-    filenames = [
-        join(V8_LIB_DIRECTORY, 'out.gn/x64.release/obj/{}'.format(object_name)),
-        join(local_path('vendor/v8/out.gn/libv8/obj/{}'.format(object_name)))
-    ]
 
-    return next((f for f in filenames if isfile(f)), None)
+    filename = join(V8_LIB_DIRECTORY, 'out.gn/x64.release/obj/{}'.format(object_name))
+
+    if not isfile(filename):
+        filename = join(local_path('vendor/v8/out.gn/libv8/obj/{}'.format(object_name)))
+
+    if not isfile(filename):
+        filename = join(V8_LIB_DIRECTORY, 'out.gn/x64.release/obj/{}'.format(object_name))
+
+    return filename
 
 
 def get_raw_static_lib_path():


### PR DESCRIPTION
Two issues crept in #66.

The first was the in the selection of the path to libv8_monolithic.a, where the code would check multiple path and return None when the lib couldn't be found. Because this code ran before building V8, it returned None and caused the build to fail.

The other one is a bit more mysterious and appear to be related to https://bugs.python.org/issue13590. Basically, Python would try to guess the linker to use (clang++) and incorrectly inferred in some circumstances the compiler with which Python 2.7 was built with, `g++-4.2`, which doesn't exist on modern Xcode installation. I have no idea why running the build a second time would make it succeed