### PR TITLE
Alpine-compatible wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,13 @@ matrix:
         - ./build_and_check_linux_wheels.sh
       after_success:
         - ./upload_artifacts_linux.sh
+    - dist: trusty
+      services:
+        - docker
+      script:
+        - ./build_and_check_linux_wheels.sh alpine
+      after_success:
+        - ./upload_artifacts_linux.sh
     - os: osx
       osx_image: xcode9.4
       compiler: clang

--- a/build_and_check_linux_wheels.sh
+++ b/build_and_check_linux_wheels.sh
@@ -28,6 +28,10 @@ do
         python:$PYTHON$docker_tag sh \
         -c "tail -f /dev/null"
 
+    if [ $# == 1 ] && [ $1 == "alpine" ]; then
+        docker exec ${CONT} sh -c 'apk add libgcc'
+    fi
+
     docker cp dist/ ${CONT}:${BASE_PATH}/dist
     docker cp tests/ ${CONT}:${BASE_PATH}/tests
     docker cp requirements/ ${CONT}:${BASE_PATH}/requirements

--- a/build_linux_musl_wheels.sh
+++ b/build_linux_musl_wheels.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+set -x
+
+# ./build_v8.sh alpine
+
+CONT=$(date +%s)
+
+mkdir -p dist
+
+for PYVERSION in 2.7 3.4 3.5 3.6 3.7; do
+
+	docker run \
+	    -e PY_MINI_RACER_V8_PATH=_v8.so \
+	    -d \
+	    --name ${CONT} python:${PYVERSION}-alpine sh \
+	    -c "tail -f /dev/null"
+
+	docker cp . ${CONT}:${BASE_PATH}
+	docker cp _v8.so ${CONT}:.
+
+    docker exec ${CONT} python setup.py sdist
+    docker exec ${CONT} python setup.py bdist_wheel
+
+	docker exec ${CONT} tar cvzf wheels.tar.gz dist/
+	docker cp ${CONT}:wheels.tar.gz .
+	tar xvf wheels.tar.gz
+	rm wheels.tar.gz
+
+	docker rm -f ${CONT}
+done
+
+for i in $(ls dist/*.whl); do 
+	auditwheel repair $i -w tmpdist
+done
+
+rm dist/*.whl
+mv tmpdist/* dist/
+rm -r tmpdist
+
+# Add wheel for Python without PyMalloc. Since we don't rely on it we can
+# safely copy the wheel with another name
+python wheel_pymalloc.py
+
+docker rm -f ${CONT}

--- a/build_linux_musl_wheels.sh
+++ b/build_linux_musl_wheels.sh
@@ -2,13 +2,13 @@
 set -e
 set -x
 
-# ./build_v8.sh alpine
-
-CONT=$(date +%s)
+./build_v8.sh alpine
 
 mkdir -p dist
 
 for PYVERSION in 2.7 3.4 3.5 3.6 3.7; do
+
+	CONT=$(date +%s)
 
 	docker run \
 	    -e PY_MINI_RACER_V8_PATH=_v8.so \
@@ -16,11 +16,26 @@ for PYVERSION in 2.7 3.4 3.5 3.6 3.7; do
 	    --name ${CONT} python:${PYVERSION}-alpine sh \
 	    -c "tail -f /dev/null"
 
+	trap "if [ -n '${CONT}' ]; then echo 'lol'; fi" EXIT
+
 	docker cp . ${CONT}:${BASE_PATH}
 	docker cp _v8.so ${CONT}:.
 
     docker exec ${CONT} python setup.py sdist
     docker exec ${CONT} python setup.py bdist_wheel
+
+    if [ PYVERSION == 3.7 ]; then
+    	docker exec ${CONT} sh -c "pip install auditwheel"
+		docker exec ${CONT} sh -c "apk add patchelf"
+		docker exec ${CONT} sh -c "for i in $(ls dist/*.whl); do; auditwheel repair $i -w tmpdist; done"
+		docker exec ${CONT} sh -c "rm dist/*.whl"
+		docker exec ${CONT} sh -c "mv tmpdist/* dist/"
+		docker exec ${CONT} sh -c "rm -r tmpdist"
+
+		# Add wheel for Python without PyMalloc. Since we don't rely on it we can
+		# safely copy the wheel with another name
+		docker exec ${CONT} sh -c "python3 wheel_pymalloc.py"
+    fi
 
 	docker exec ${CONT} tar cvzf wheels.tar.gz dist/
 	docker cp ${CONT}:wheels.tar.gz .
@@ -28,18 +43,6 @@ for PYVERSION in 2.7 3.4 3.5 3.6 3.7; do
 	rm wheels.tar.gz
 
 	docker rm -f ${CONT}
+	unset CONT
+
 done
-
-for i in $(ls dist/*.whl); do 
-	auditwheel repair $i -w tmpdist
-done
-
-rm dist/*.whl
-mv tmpdist/* dist/
-rm -r tmpdist
-
-# Add wheel for Python without PyMalloc. Since we don't rely on it we can
-# safely copy the wheel with another name
-python wheel_pymalloc.py
-
-docker rm -f ${CONT}

--- a/build_so.sh
+++ b/build_so.sh
@@ -4,11 +4,10 @@ set -x
 
 VERSION=6.7.288.46.1
 
-libc=$(ldd /bin/cat | grep musl)
-if [ -z "$libc" ]; then
-    URL=https://rubygems.org/downloads/libv8-$VERSION-x86_64-linux.gem
-else
+if [ $# == 1 ] && [ $1 == "alpine" ]; then
     URL=https://rubygems.org/downloads/libv8-alpine-$VERSION-x86_64-linux.gem
+else
+    URL=https://rubygems.org/downloads/libv8-$VERSION-x86_64-linux.gem
 fi
 
 [[ -f libv8.gem ]] || curl "$URL" --output libv8.gem

--- a/build_so.sh
+++ b/build_so.sh
@@ -3,7 +3,14 @@ set -e
 set -x
 
 VERSION=6.7.288.46.1
-URL=https://rubygems.org/downloads/libv8-$VERSION-x86_64-linux.gem
+
+libc=$(ldd /bin/cat | grep musl)
+if [ -z "$libc" ]; then
+    URL=https://rubygems.org/downloads/libv8-$VERSION-x86_64-linux.gem
+else
+    URL=https://rubygems.org/downloads/libv8-alpine-$VERSION-x86_64-linux.gem
+fi
+
 [[ -f libv8.gem ]] || curl "$URL" --output libv8.gem
 tar xvf libv8.gem
 tar xvf data.tar.gz

--- a/build_v8.sh
+++ b/build_v8.sh
@@ -12,13 +12,14 @@ CONT=$(date +%s)
 
 docker run -d --name ${CONT} $distribution sh -c "tail -f /dev/null"
 
-if [ "$distribution" == "alpine" ]; then
-	docker exec ${CONT} sh -c "apk update; apk add bash curl g++"
-fi
-
 docker cp . ${CONT}:${BASE_PATH}
 
-docker exec ${CONT} bash build_so.sh
+if [ "$distribution" == "alpine" ]; then
+	docker exec ${CONT} sh -c "apk update; apk add bash curl g++"
+	docker exec ${CONT} bash build_so.sh alpine
+else
+	docker exec ${CONT} bash build_so.sh
+fi
 
 docker cp ${CONT}:_v8.so .
 

--- a/build_v8.sh
+++ b/build_v8.sh
@@ -2,9 +2,19 @@
 set -e
 set -x
 
+if [ $# == 1 ] && [ $1 == "alpine" ]; then
+	distribution="alpine"
+else
+	distribution="quay.io/pypa/manylinux1_x86_64"
+fi
+
 CONT=$(date +%s)
 
-docker run -d --name ${CONT} quay.io/pypa/manylinux1_x86_64 bash -c "mkdir /${BASE_PATH}; tail -f /var/log/lastlog"
+docker run -d --name ${CONT} $distribution sh -c "tail -f /dev/null"
+
+if [ "$distribution" == "alpine" ]; then
+	docker exec ${CONT} sh -c "apk update; apk add bash curl g++"
+fi
 
 docker cp . ${CONT}:${BASE_PATH}
 


### PR DESCRIPTION
Because Alpine is not officially supported by `pip`, we will provide `manylinux` wheels for the glibc-compatible linux distributions, and `linux` wheels which are actually the Alpine ones. Because pip should always use `manylinux` when available, this should work.