### PR TITLE
Added basic support for the Symbol type introduced in ECMAScript 6.

### DIFF
--- a/py_mini_racer/extension/mini_racer_extension.cc
+++ b/py_mini_racer/extension/mini_racer_extension.cc
@@ -30,6 +30,7 @@ enum BinaryTypes {
     type_array     =   6,
     type_hash      =   7,
     type_date      =   8,
+    type_symbol    =   9,
 
     type_function  = 100,
 
@@ -92,6 +93,7 @@ void BinaryValueFree(BinaryValue *v) {
     case type_null:
     case type_integer:
     case type_function: // no value implemented
+    case type_symbol:
     case type_invalid:
         // the other types are scalar values
         break;
@@ -419,6 +421,10 @@ static BinaryValue *convert_v8_to_binary(ContextInfo *context_info,
 
     else if (value->IsFunction()){
         res->type = type_function;
+    }
+
+    else if (value->IsSymbol()){
+        res->type = type_symbol;
     }
 
     else if (value->IsDate()) {

--- a/py_mini_racer/py_mini_racer.py
+++ b/py_mini_racer/py_mini_racer.py
@@ -55,6 +55,9 @@ class JSFunction(object):
     """ type for JS functions """
     pass
 
+class JSSymbol(object):
+    """ type for JS symbols """
+    pass
 
 def is_unicode(value):
     """ Check if a value is a valid unicode string, compatible with python 2 and python 3
@@ -223,6 +226,7 @@ class PythonTypes(object):
     array     =   6
     hash      =   7
     date      =   8
+    symbol    =   9
 
     function  = 100
 
@@ -303,6 +307,8 @@ class PythonValue(ctypes.Structure):
             timestamp = self._double_value()
             # JS timestamp are milliseconds, in python we are in seconds
             result = datetime.datetime.utcfromtimestamp(timestamp / 1000.)
+        elif self.type == PythonTypes.symbol:
+            result = JSSymbol()
         else:
             raise WrongReturnTypeException("unknown type %d" % self.type)
         return result

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -8,7 +8,6 @@ import unittest
 import six
 
 from py_mini_racer import py_mini_racer
-from py_mini_racer.py_mini_racer import JSSymbol
 
 class Test(unittest.TestCase):
     """ Test basic types """
@@ -100,7 +99,7 @@ class Test(unittest.TestCase):
 
     def test_symbol(self):
         res = self.mr.eval('Symbol.toPrimitive')
-        self.assertEqual(type(res), JSSymbol)
+        self.assertEqual(type(res), py_mini_racer.JSSymbol)
 
 
 if __name__ == '__main__':

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -8,6 +8,7 @@ import unittest
 import six
 
 from py_mini_racer import py_mini_racer
+from py_mini_racer.py_mini_racer import JSSymbol
 
 class Test(unittest.TestCase):
     """ Test basic types """
@@ -95,6 +96,11 @@ class Test(unittest.TestCase):
                     n.fill(0);
                     a = a.concat(n);
                 }''', max_memory=200000000)
+
+
+    def test_symbol(self):
+        res = self.mr.eval('Symbol.toPrimitive')
+        self.assertEqual(type(res), JSSymbol)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This prevents segmentation faults when evaluating a statement that results in a Symbol.

Related issue: https://github.com/sqreen/PyMiniRacer/issues/82
