### PR TITLE
Add support for soft memory limit

### DIFF
--- a/py_mini_racer/extension/mini_racer_extension.cc
+++ b/py_mini_racer/extension/mini_racer_extension.cc
@@ -9,6 +9,7 @@
 #include <v8-profiler.h>
 #include <libplatform/libplatform.h>
 
+
 template<class T> static inline T* xalloc(T*& ptr, size_t x = sizeof(T))
 {
     void *tmp = malloc(x);
@@ -119,6 +120,10 @@ struct ContextInfo {
     Persistent<Context>* context;
     ArrayBufferAllocator* allocator;
     bool interrupted;
+    size_t soft_memory_limit;
+    bool soft_memory_limit_reached;
+    size_t hard_memory_limit;
+    bool hard_memory_limit_reached;
 };
 
 struct EvalResult {
@@ -154,24 +159,27 @@ typedef struct {
     size_t max_memory;
 } EvalParams;
 
-enum IsolateFlags {
-    MEM_SOFTLIMIT_VALUE,
-    MEM_SOFTLIMIT_REACHED,
+enum IsolateData {
+    CONTEXT_INFO,
 };
 
 static Platform* current_platform = NULL;
 
 static void gc_callback(Isolate *isolate, GCType type, GCCallbackFlags flags) {
-    if((bool)isolate->GetData(MEM_SOFTLIMIT_REACHED)) return;
+    ContextInfo * context_info = (ContextInfo *)isolate->GetData(CONTEXT_INFO);
 
-    size_t softlimit = *(size_t*) isolate->GetData(MEM_SOFTLIMIT_VALUE);
+    if (context_info == nullptr) {
+        return;
+    }
 
     HeapStatistics stats;
     isolate->GetHeapStatistics(&stats);
     size_t used = stats.used_heap_size();
 
-    if(used > softlimit) {
-        isolate->SetData(MEM_SOFTLIMIT_REACHED, (void*)true);
+    context_info->soft_memory_limit_reached = (used > context_info->soft_memory_limit);
+    isolate->MemoryPressureNotification((context_info->soft_memory_limit_reached) ? v8::MemoryPressureLevel::kModerate : v8::MemoryPressureLevel::kNone);
+    if(used > context_info->hard_memory_limit) {
+        context_info->hard_memory_limit_reached = true;
         isolate->TerminateExecution();
     }
 }
@@ -194,6 +202,11 @@ static void* breaker(void *d) {
   return NULL;
 }
 
+static void set_hard_memory_limit(ContextInfo *context_info, size_t limit) {
+    context_info->hard_memory_limit = limit;
+    context_info->hard_memory_limit_reached = false;
+}
+
 static void* nogvl_context_eval(void* arg) {
     EvalParams* eval_params = (EvalParams*)arg;
     EvalResult* result = eval_params->result;
@@ -207,10 +220,7 @@ static void* nogvl_context_eval(void* arg) {
 
     Context::Scope context_scope(context);
 
-    // Memory softlimit
-    isolate->SetData(MEM_SOFTLIMIT_VALUE, (void*)false);
-    // Memory softlimit hit flag
-    isolate->SetData(MEM_SOFTLIMIT_REACHED, (void*)false);
+    set_hard_memory_limit(eval_params->context_info, eval_params->max_memory);
 
     MaybeLocal<Script> parsed_script = Script::Compile(context, *eval_params->eval);
     result->parsed = !parsed_script.IsEmpty();
@@ -233,7 +243,6 @@ static void* nogvl_context_eval(void* arg) {
         }
         // memory limit
         if (eval_params->max_memory > 0) {
-            isolate->SetData(MEM_SOFTLIMIT_VALUE, &eval_params->max_memory);
             isolate->AddGCEpilogueCallback(gc_callback);
         }
 
@@ -525,8 +534,8 @@ ContextInfo *MiniRacer_init_context()
     init_v8();
 
     ContextInfo* context_info = xalloc(context_info);
+    memset(context_info, 0, sizeof(*context_info));
     context_info->allocator = new ArrayBufferAllocator();
-    context_info->interrupted = false;
     Isolate::CreateParams create_params;
     create_params.array_buffer_allocator = context_info->allocator;
 
@@ -540,6 +549,7 @@ ContextInfo *MiniRacer_init_context()
 
     context_info->context = new Persistent<Context>();
     context_info->context->Reset(context_info->isolate, context);
+    context_info->isolate->SetData(CONTEXT_INFO, (void *)context_info);
 
     return context_info;
 }
@@ -627,8 +637,7 @@ static BinaryValue* MiniRacer_eval_context_unsafe(
         result = xalloc(result);
         result->str_val = nullptr;
 
-        bool mem_softlimit_reached = (bool)context_info->isolate->GetData(MEM_SOFTLIMIT_REACHED);
-        if (mem_softlimit_reached) {
+        if (context_info->hard_memory_limit_reached) {
             result->type = type_oom_exception;
         } else {
             if (eval_result.timed_out) {
@@ -725,9 +734,24 @@ BinaryValue *mr_heap_stats(ContextInfo *context_info) {
     return heap_stats(context_info);
 }
 
+void mr_set_hard_memory_limit(ContextInfo *context_info, size_t limit) {
+    set_hard_memory_limit(context_info, limit);
+}
+
+void mr_set_soft_memory_limit(ContextInfo *context_info, size_t limit) {
+    context_info->soft_memory_limit = limit;
+    context_info->soft_memory_limit_reached = false;
+}
+
+bool mr_soft_memory_limit_reached(ContextInfo *context_info) {
+    return context_info->soft_memory_limit_reached;
+}
+
 void mr_low_memory_notification(ContextInfo *context_info) {
     context_info->isolate->LowMemoryNotification();
 }
+
+
 
 // FOR DEBUGGING ONLY
 BinaryValue* mr_heap_snapshot(ContextInfo *context_info) {

--- a/py_mini_racer/py_mini_racer.py
+++ b/py_mini_racer/py_mini_racer.py
@@ -116,6 +116,12 @@ def _fetch_ext_handle():
     _ext_handle.mr_heap_snapshot.argtypes = [ctypes.c_void_p]
     _ext_handle.mr_heap_snapshot.restype = ctypes.POINTER(PythonValue)
 
+    _ext_handle.mr_set_soft_memory_limit.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+    _ext_handle.mr_set_soft_memory_limit.restype = None
+
+    _ext_handle.mr_soft_memory_limit_reached.argtypes = [ctypes.c_void_p]
+    _ext_handle.mr_soft_memory_limit_reached.restype = ctypes.c_bool
+
     return _ext_handle
 
 
@@ -135,6 +141,14 @@ class MiniRacer(object):
         """ Free value returned by mr_eval_context """
 
         self.ext.mr_free_value(res)
+
+    def set_soft_memory_limit(self, limit):
+        """ Set instance soft memory limit """
+        self.ext.mr_set_soft_memory_limit(self.ctx, limit)
+
+    def was_soft_memory_limit_reached(self):
+        """ Tell if the instance soft memory limit was reached """
+        return self.ext.mr_soft_memory_limit_reached(self.ctx)
 
     def execute(self, js_str, timeout=0, max_memory=0):
         """ Exec the given JS value """

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -84,7 +84,21 @@ class Test(unittest.TestCase):
             duration = time.clock() - start_time
             assert timeout_ms <= duration * 1000 <= timeout_ms + 10
 
-    def test_max_memory(self):
+    def test_max_memory_soft(self):
+        self.mr.set_soft_memory_limit(100000000)
+        with self.assertRaises(py_mini_racer.JSOOMException):
+            self.mr.eval('''let s = 1000;
+                var a = new Array(s);
+                a.fill(0);
+                while(true) {
+                    s *= 1.1;
+                    let n = new Array(Math.floor(s));
+                    n.fill(0);
+                    a = a.concat(n);
+                }''', max_memory=200000000)
+        self.assertEqual(self.mr.was_soft_memory_limit_reached(), True)
+
+    def test_max_memory_hard(self):
         with self.assertRaises(py_mini_racer.JSOOMException):
             self.mr.eval('''let s = 1000;
                 var a = new Array(s);


### PR DESCRIPTION
The `max_memory` support has not changed, it was renamed internally to hard memory limit because it will stop execution of the context if reached. The soft memory limit however, won't stop the execution but tell the GC to be more aggressive on freeing memory.