### PR TITLE
fix: add Apple Silicon support

### DIFF
--- a/py_mini_racer/py_mini_racer.py
+++ b/py_mini_racer/py_mini_racer.py
@@ -22,11 +22,15 @@ def _get_libc_name():
         return "muslc"
     return "glibc"
 
+def is_apple_silicon():
+    return sys.platform == 'darwin' and sys.maxsize > 2**32
 
 def _get_lib_path(name):
     """Return the path of the library called `name` on the current system."""
     if os.name == "posix" and sys.platform == "darwin":
         prefix, ext = "lib", ".dylib"
+        if is_apple_silicon():
+            prefix = "armlib"
     elif sys.platform == "win32":
         prefix, ext = "", ".dll"
     else:


### PR DESCRIPTION
On Apple Silicon platforms (such as M1 and M2), the `mini_racer` library is compiled as `armlibmini_racer.dylib` instead of `libmini_racer.dylib`. Using the incorrect library path may cause a runtime exception.

To address this issue, we introduce a runtime check to determine if the current system is running on Apple Silicon. We utilize the `sys` module to inspect the system's characteristics.

Here's how the check works:

1. We use `sys.platform` to check the identifier of the current operating system. For macOS systems, the value of `sys.platform` is 'darwin'.

2. We use `sys.maxsize` to check the maximum integer value supported by the current Python interpreter. On Apple Silicon devices, due to the 64-bit architecture, the value of `sys.maxsize` is greater than 2^32.

3. If `sys.platform` is equal to 'darwin' and `sys.maxsize` is greater than 2^32, it indicates that the current system is Apple Silicon, and the function returns `True`. Otherwise, the function returns `False`.

Here's the code snippet that implements this check:

```python
import sys

def is_apple_silicon():
    return sys.platform == 'darwin' and sys.maxsize > 2**32
```

By incorporating this check into the library's initialization process, we can dynamically determine the appropriate library path based on the underlying system architecture.

If the `is_apple_silicon()` function returns `True`, we use the `armlibmini_racer.dylib` library path. Otherwise, we fallback to the default `libmini_racer.dylib` path.

This runtime detection ensures that the `mini_racer` library is correctly loaded on Apple Silicon systems, preventing potential runtime exceptions caused by using the incorrect library path.

Please note that this workaround assumes that the operating system running on Apple Silicon devices is macOS and that a 64-bit Python interpreter is being used. If these assumptions change in the future, the detection logic may need to be updated accordingly.